### PR TITLE
fix: Fix expandRange behavior for costOptimized reviewType

### DIFF
--- a/code-review-gpt/src/review/prompt/constructPrompt/batchFiles/utils/createPromptFiles.ts
+++ b/code-review-gpt/src/review/prompt/constructPrompt/batchFiles/utils/createPromptFiles.ts
@@ -142,8 +142,10 @@ export const createPromptFiles = (
       maxSurroundingLines
     );
 
-    // Expand the range and create the prompt content
-    ({ start, end } = expandRange(start, end, contentLines, remainingSpace));
+    // Expand the range and create the prompt content, only if maxSurroundingLines is defined
+    if (!maxSurroundingLines) {
+      ({ start, end } = expandRange(start, end, contentLines, remainingSpace));
+    }
     const promptContent = createPromptContent(
       start,
       end,


### PR DESCRIPTION
Thanks for this wonderful project, It helped me a lot.
I found a bug when I use reviewType 'costOptimized',  that uncessary expandRange function call, make reviewtype 'costOptimized' just like the reviewType 'changed',  this is my fix, please think about this.