### PR TITLE
Updating path for npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See the [action documentation](action.md) for more information.
 
    ```shell
    git clone https://github.com/mattzcarey/code-review-gpt.git
-   cd code-review-gpt && cd code-review-gpt
+   cd code-review-gpt && cd packages/code-review-gpt
    ```
 
 2. Install dependencies:


### PR DESCRIPTION
NPM package code-review-gpt is present inside /packages directory. Current installation instructions assume a different folder structure and lead to "no such directory" error.