### PR TITLE
feat: support Terraform code review

### DIFF
--- a/packages/code-review-gpt/src/review/constants.ts
+++ b/packages/code-review-gpt/src/review/constants.ts
@@ -41,6 +41,8 @@ export const languageMap: { [key: string]: string } = {
   ".kts": "Kotlin",
   ".java": "Java",
   ".vue": "Vue",
+  ".tf": "Terraform",
+  ".hcl": "Terraform",
 };
 
 export const supportedFiles = new Set(Object.keys(languageMap));


### PR DESCRIPTION
Support HashiCorp Terraform code review:

- `.tf`: Terraform file
- `.hcl`: HashiCorp Configuration Language

I have tested both file extensions with the 'gpt-3.5-turbo' model.  It works great.

**Example**
----------------------------------

**Risk Level 3 - variables.tf**

The code changes in this file have a medium risk to the code base. Here are a few suggestions for improvement:

1. The `enabled` variable can have a more descriptive name. Consider renaming it to something like `diagnosticsEnabled`.

2. The `diag_object` variable can be defined as a complex object type to improve readability and maintainability. Consider using a map or a struct to define the structure of the `diag_object` variable.

Example:

```hcl
variable \"diag_object\" {
  description = \"(Required) Contains the diagnostics setting object.\"
  type        = map(object({
    diagnosticsEnabled = bool
    retentionEnabled   = bool
    retentionPeriod    = number
  }))
}
```