### PR TITLE
feat: add gpt-4-turbo support

### DIFF
--- a/packages/code-review-gpt/package.json
+++ b/packages/code-review-gpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-review-gpt",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Your AI code reviewer. Improve code quality and catch bugs before you break production",
   "bin": {
     "code-review-gpt": "./dist/index.js"

--- a/packages/code-review-gpt/src/review/constants.ts
+++ b/packages/code-review-gpt/src/review/constants.ts
@@ -3,6 +3,14 @@ export const signOff =
 
 export const modelInfo = [
   {
+    model: "gpt-4-turbo",
+    maxPromptLength: 128000, //128k tokens
+  },
+  {
+    model: "gpt-4-turbo-preview",
+    maxPromptLength: 128000, //128k tokens
+  },
+  {
     model: "gpt-4-1106-preview",
     maxPromptLength: 128000, //128k tokens
   },


### PR DESCRIPTION
Two new models, 'gpt-4-turbo' and 'gpt-4-turbo-preview', have been added to the modelInfo array in the constants file. Both have a maximum prompt length of 128k tokens.