### PR TITLE
feat: Add GITLAB_HOST CI/CD Variable for GitLab Self-Hosted Server

### DIFF
--- a/packages/code-review-gpt/src/common/ci/gitlab/commentOnPR.ts
+++ b/packages/code-review-gpt/src/common/ci/gitlab/commentOnPR.ts
@@ -14,12 +14,12 @@ export const commentOnPR = async (
   signOff: string
 ): Promise<void> => {
   try {
-    const { gitlabToken, projectId, mergeRequestIIdString, host } =
+    const { gitlabToken, projectId, mergeRequestIIdString, gitlabHost } =
       getGitLabEnvVariables();
     const mergeRequestIId = parseInt(mergeRequestIIdString, 10);
     const api = new Gitlab({
       token: gitlabToken,
-      host: host,
+      host: gitlabHost,
     });
 
     const notes = await api.MergeRequestNotes.all(projectId, mergeRequestIId);

--- a/packages/code-review-gpt/src/common/ci/gitlab/commentOnPR.ts
+++ b/packages/code-review-gpt/src/common/ci/gitlab/commentOnPR.ts
@@ -14,11 +14,12 @@ export const commentOnPR = async (
   signOff: string
 ): Promise<void> => {
   try {
-    const { gitlabToken, projectId, mergeRequestIIdString } =
+    const { gitlabToken, projectId, mergeRequestIIdString, host } =
       getGitLabEnvVariables();
     const mergeRequestIId = parseInt(mergeRequestIIdString, 10);
     const api = new Gitlab({
       token: gitlabToken,
+      host: host,
     });
 
     const notes = await api.MergeRequestNotes.all(projectId, mergeRequestIId);

--- a/packages/code-review-gpt/src/config.ts
+++ b/packages/code-review-gpt/src/config.ts
@@ -48,6 +48,7 @@ export const getGitLabEnvVariables = (): Record<string, string> => {
     "CI_MERGE_REQUEST_IID",
     "CI_COMMIT_SHA",
     "GITLAB_TOKEN",
+    "GITLAB_HOST",
   ].filter((varName) => !process.env[varName]);
   if (missingVars.length > 0) {
     logger.error(`Missing environment variables: ${missingVars.join(", ")}`);
@@ -62,6 +63,7 @@ export const getGitLabEnvVariables = (): Record<string, string> => {
     gitlabToken: process.env.GITLAB_TOKEN ?? "",
     projectId: process.env.CI_PROJECT_ID ?? "",
     mergeRequestIIdString: process.env.CI_MERGE_REQUEST_IID ?? "",
+    host: process.env.GITLAB_HOST ?? "https://gitlab.com",
   };
 };
 

--- a/packages/code-review-gpt/src/config.ts
+++ b/packages/code-review-gpt/src/config.ts
@@ -63,7 +63,7 @@ export const getGitLabEnvVariables = (): Record<string, string> => {
     gitlabToken: process.env.GITLAB_TOKEN ?? "",
     projectId: process.env.CI_PROJECT_ID ?? "",
     mergeRequestIIdString: process.env.CI_MERGE_REQUEST_IID ?? "",
-    host: process.env.GITLAB_HOST ?? "https://gitlab.com",
+    gitlabHost: process.env.GITLAB_HOST ?? "https://gitlab.com",
   };
 };
 


### PR DESCRIPTION
Hello,

Thanks for sharing this awesome project.
This little patch fixes the following issue with Gitlab integration:
1. Support self-hosted gitlab server with GITLAB_HOST  variable (= CI/CD Variable for gitlab)
2. If you do not set the GITLAB_HOST value, the default value of https://gitlab.com is used.