### PR TITLE
fix: error gpt model

### DIFF
--- a/action.md
+++ b/action.md
@@ -61,6 +61,6 @@ jobs:
         uses: mattzcarey/code-review-gpt@v0.1.10
         with:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          MODEL: 'gpt-4o'
+          MODEL: 'gpt-4o-mini' # reference: https://platform.openai.com/settings/organization/limits
           GITHUB_TOKEN: ${{ github.token }}
 ```


### PR DESCRIPTION
Using the previously specified `gpt-4o` model results in a job failure error
(Please refer to the [link](https://platform.openai.com/settings/organization/limits) for the GPT model)

![image](https://github.com/user-attachments/assets/afe6959b-6e07-4b5e-8e08-a340f3ad7947)


When using other models specified in the link above, the job runs successfully

![image](https://github.com/user-attachments/assets/d81d9a04-8a4b-456e-9054-fbc2f188d299)
