### PR TITLE
feat: add support for arbitrary OpenAI compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ See the [action documentation](action.md) for more information.
 
 When used globally you should run `export OPENAI_API_KEY=YOUR_API_KEY` (or similar for your operating system) in your terminal to set the API key.
 
+To use an OpenAI compatible API, you can set the `OPENAI_API_KEY` and `OPENAI_BASE_URL` environment variables and specify the model name when running the review command:
+
+```shell
+export OPENAI_API_KEY=<YOUR_API_KEY>
+export OPENAI_BASE_URL=<YOUR_ENDPOINT>
+bun review --model <YOUR_MODEL_NAME>
+```
+
 4. Run the application:
 
    ```shell

--- a/src/common/model/getMaxPromptLength.ts
+++ b/src/common/model/getMaxPromptLength.ts
@@ -1,14 +1,16 @@
 import { modelInfo } from '../../review/constants';
+import { logger } from '../utils/logger';
+
+const DEFAULT_MAX_PROMPT_LENGTH = 65536;
 
 export const getMaxPromptLength = (modelName: string): number => {
   const maxPromptLength = modelInfo.find((info) => info.model === modelName)?.maxPromptLength;
 
   if (!maxPromptLength) {
-    throw new Error(
-      `Model ${modelName} not found. Please choose one of ${modelInfo
-        .map((info) => info.model)
-        .toString()} or make a PR to add a new model.`
+    logger.warn(
+      `Model ${modelName} not found in predefined list. Using default max prompt length (${DEFAULT_MAX_PROMPT_LENGTH} chars).`
     );
+    return DEFAULT_MAX_PROMPT_LENGTH;
   }
 
   return maxPromptLength;


### PR DESCRIPTION
This PR adds support for OpenAI-compatible APIs, including interfaces for closed-source LLM APIs, open-source LLM inference services, and self-deployed LLMs. It also supports arbitrary model names.

example usage:
```
OPENAI_API_KEY="XXX" OPENAI_BASE_URL="https://api.deepinfra.com/v1/openai" bun review --model deepseek-ai/DeepSeek-V3
```